### PR TITLE
fix build with CMake 4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-project (reiserfs-defrag)
+cmake_minimum_required (VERSION 2.6...4.1)
 
-cmake_minimum_required (VERSION 2.6)
+project (reiserfs-defrag)
 
 add_executable (reiserfs-defrag
 	defrag.cpp

--- a/misc/CMakeLists.txt
+++ b/misc/CMakeLists.txt
@@ -1,6 +1,6 @@
-project (reiserfs-toys)
+cmake_minimum_required (VERSION 2.6...4.1)
 
-cmake_minimum_required (VERSION 2.6)
+project (reiserfs-toys)
 
 add_library (mrfsu STATIC
 	../reiserfs.cpp


### PR DESCRIPTION
CMake 4.0 has removed compatibility with CMake < 3.5. Declare that policies up to 4.1 are working and move the call to the top of CMakeLists.txt to keep newer CMake versions happy.

Closes: https://github.com/i-rinat/reiserfs-defrag/issues/5